### PR TITLE
Add new "hll" bucket type

### DIFF
--- a/devrel/riak-cluster-config
+++ b/devrel/riak-cluster-config
@@ -11,6 +11,7 @@ $riak_admin bucket-type create mr
 $riak_admin bucket-type create no_siblings '{"props":{"allow_mult":"false"}}'
 $riak_admin bucket-type create maps '{"props":{"datatype":"map"}}'
 $riak_admin bucket-type create sets '{"props":{"datatype":"set"}}'
+$riak_admin bucket-type create hlls '{"props":{"datatype":"hll"}}'
 $riak_admin bucket-type create counters '{"props":{"datatype":"counter"}}'
 $riak_admin bucket-type create other_counters '{"props":{"datatype":"counter","allow_mult":true}}'
 $riak_admin bucket-type create yokozuna '{"props":{}}'
@@ -26,6 +27,7 @@ $riak_admin bucket-type activate mr
 $riak_admin bucket-type activate no_siblings
 $riak_admin bucket-type activate maps
 $riak_admin bucket-type activate sets
+$riak_admin bucket-type activate hlls
 $riak_admin bucket-type activate counters
 $riak_admin bucket-type activate other_counters
 $riak_admin bucket-type activate yokozuna


### PR DESCRIPTION
This is needed for unit testing the new hyperloglog functionality in riak-erlang-client.
