### PR TITLE
Allow mapreduce function as string

### DIFF
--- a/lib/gen_adv_conf.bash
+++ b/lib/gen_adv_conf.bash
@@ -4,6 +4,7 @@ function gen_adv_conf
     cat > $out_file <<'EOT'
 [
     {riak_kv, [
+        {allow_strfun, true},
         {delete_mode, immediate},
         {test, true}
     ]},


### PR DESCRIPTION
This is needed in order to allow for rebase of riakc PR https://github.com/basho/riak-erlang-client/pull/317

Item `allow_strfun` put first as it is the only one listed in `riak_kv.app.src`.